### PR TITLE
Update calico to 3.21.4 to match calicoctl

### DIFF
--- a/calico.yaml
+++ b/calico.yaml
@@ -3430,7 +3430,7 @@ spec:
         # It can be deleted if this is a fresh installation, or if you have already
         # upgraded to use calico-ipam.
         - name: upgrade-ipam
-          image: docker.io/calico/cni:v3.21.2
+          image: docker.io/calico/cni:v3.21.4
           command: ["/opt/cni/bin/calico-ipam", "-upgrade"]
           envFrom:
           - configMapRef:
@@ -3459,7 +3459,7 @@ spec:
         # This container installs the CNI binaries
         # and CNI network config file on each node.
         - name: install-cni
-          image: docker.io/calico/cni:v3.21.2
+          image: docker.io/calico/cni:v3.21.4
           command: ["/opt/cni/bin/install"]
           envFrom:
           - configMapRef:
@@ -3500,7 +3500,7 @@ spec:
         # Adds a Flex Volume Driver that creates a per-pod Unix Domain Socket to allow Dikastes
         # to communicate with Felix over the Policy Sync API.
         - name: flexvol-driver
-          image: docker.io/calico/pod2daemon-flexvol:v3.21.2
+          image: docker.io/calico/pod2daemon-flexvol:v3.21.4
           volumeMounts:
           - name: flexvol-driver-host
             mountPath: /host/driver
@@ -3511,7 +3511,7 @@ spec:
         # container programs network policy and routes on each
         # host.
         - name: calico-node
-          image: docker.io/calico/node:v3.21.2
+          image: docker.io/calico/node:v3.21.4
           envFrom:
           - configMapRef:
               # Allow KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT to be overridden for eBPF mode.


### PR DESCRIPTION
I ran the existing one in my cluster fine. Then changed just the version numbers, re-applied and it still worked after rebuilding the pods.